### PR TITLE
Issue #26:  Add 'make clean-data' to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ clean:
 	- docker rm $(docker-compose ps -q)
 	- docker-compose ps
 
+clean-data:
+	- docker volume rm autismcasestudy_mysql-data
+
 stop:
 	- docker-compose down
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ To remove the containers:
 make clean
 `
 
+To remove the data container (where the database is stored):
+`
+make clean-data
+`
+
 To shell into the php container:
 `
 docker-compose exec --user 82 php /bin/sh


### PR DESCRIPTION
Adds "make clean-data" to the Makefile so that the data
container can be removed to completely reset the
development environment.

Updates the README to add the make command.