### PR TITLE
Update `Makefile` for Sequel Pro access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
 #      - ./docker-runtime/mariadb:/var/lib/mysql
       - mysql-data:/var/lib/mysql
       - ./db:/docker-entrypoint-initdb.d # Place init .sql file(s) here.
+    ports:
+      - '33306:3306'
 
   php:
     image: wodby/drupal-php:5.6 # Allowed: 7.0, 5.6.


### PR DESCRIPTION
Added a `port` variable to the `mariadb` container section in the `Makefile`.  This let's me use Sequel Pro to visualize the DB and help while making changes. 