### PR TITLE
Issue #7: Removing the period from the end of the custom step

### DIFF
--- a/tests/features/bootstrap/RolesPermissionsContext.php
+++ b/tests/features/bootstrap/RolesPermissionsContext.php
@@ -91,7 +91,7 @@ class RolesPermissionsContext extends RawDrupalContext implements SnippetAccepti
   /**
    * Checks that a role has all available permissions.
    *
-   * @Then I can see that the :role role has all available permissions.
+   * @Then I can see that the :role role has all available permissions
    */
   public function iCanSeeThatTheRoleHasAllAvailablePermissions($role) {
     $role_permissions = $this->getPermissionsForRole($role);


### PR DESCRIPTION
Inadvertently added a period to the end of the custom step regex, causing it to not be recognized as a proper step.

Period is removed.