### PR TITLE
Issue #29: Delete watchdog log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,3 @@ install:
 script:
   - docker-compose exec -T --user 82 php tests/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme www/sites/all/modules/custom www/sites/all/themes/custom --ignore=*.css,*.min.js,*addthis_widget.js,*features.*.inc
   - docker-compose exec -T --user 82 php tests/bin/behat -c tests/behat.yml
-
-after_failure:
-#  - docker exec -it duketoday_php bin/upload-textfiles "/var/log/httpd/ssl_request_log"
-#  - docker exec -it duketoday_php bin/upload-textfiles "/var/log/httpd/ssl_access_log"
-#  - docker exec -it duketoday_php bin/upload-textfiles "/var/log/httpd/ssl_error_log"
-#  - docker exec -it duketoday_php bin/drush ws --count=1000 --extended > $TRAVIS_BUILD_DIR/tests/logs/watchdog.log
-#  - docker exec -it duketoday_php bin/upload-textfiles "$TRAVIS_BUILD_DIR/tests/logs/*.log"
-#  - docker exec -it duketoday_php bin/upload-screenshots "$TRAVIS_BUILD_DIR/tests/logs/*.png"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:
 	- docker-compose exec --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
 	- docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer
 	- docker-compose exec --user 82 php drush @dev wd-del all -y
+	- make provision
 provision:
 	- docker-compose exec --user 82 php drush @dev updb -y
 	- docker-compose exec --user 82 php drush @dev fra -y

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	- docker-compose exec --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
 	- docker-compose exec --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
 	- docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer
-	- make provision
+	- docker-compose exec --user 82 php drush @dev wd-del all -y
 provision:
 	- docker-compose exec --user 82 php drush @dev updb -y
 	- docker-compose exec --user 82 php drush @dev fra -y


### PR DESCRIPTION
Issue #29 

Deletes the watchdog log after importing a new database.  Also
removes some extraneous commented out lines from the travis
config file.
