### PR TITLE
Issue #39: Resources View

### DIFF
--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -36,7 +36,6 @@ Feature: Checks "Resources" View
     Given I am logged in as a user with the "anonymous user" role
     When I visit "/resources"
     Then the "<view-row>" element should contain "<title>"
-    #Then the ".views-row-1" element should contain "Test Resource1.1"
     Examples:
       |view-row      |title            |
       |.views-row-1  |Test Resource1.1 |
@@ -49,7 +48,7 @@ Feature: Checks "Resources" View
       |.views-row-8  |Test Resource4.2 |
 
   # Scenario 3
-  @api @39 @now
+  @api @39
   Scenario Outline: Check the category filter works
     Given "resource" content:
       |title          |status |field_resource_category      |

--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -20,7 +20,7 @@ Feature: Checks "Resources" View
       |administrator      |
 
   # Scenario 2
-  @api @39 @now
+  @api @39
   Scenario Outline: Check content is being sorted by category and title
     Given "resource" content:
       |title            |status |field_resource_category  |
@@ -47,3 +47,24 @@ Feature: Checks "Resources" View
       |.views-row-6  |Test Resource3.2 |
       |.views-row-7  |Test Resource4.1 |
       |.views-row-8  |Test Resource4.2 |
+
+  # Scenario 3
+  @api @39 @now
+  Scenario Outline: Check the category filter works
+    Given "resource" content:
+      |title          |status |field_resource_category      |
+      |Test Resource1 |1      |Resources for Caregivers     |
+      |Test Resource2 |1      |Resources for Parents        |
+      |Test Resource3 |1      |Resources for People with AS |
+      |Test Resource4 |1      |Resources for Teachers       |
+
+    Given I am logged in as a user with the "anonymous user" role
+    When I visit "/resources"
+    And I select "<category>" from "Category"
+    Then I should see "<title>"
+    Examples:
+      |category                     |title          |
+      |Resources for Caregivers     |Test Resource1 |
+      |Resources for Parents        |Test Resource2 |
+      |Resources for People with AS |Test Resource3 |
+      |Resources for Teachers       |Test Resource4 |

--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -1,7 +1,7 @@
 Feature: Checks "Resources" View
   As a developer, I need to verify:
   That the "Resources" view page exists and correct roles can view page
-  That the sort and filters work
+  That the sort, filters, and links work
 
   # Scenarios for "Resources" View Page
 
@@ -67,3 +67,15 @@ Feature: Checks "Resources" View
       |Resources for Parents        |Test Resource2 |
       |Resources for People with AS |Test Resource3 |
       |Resources for Teachers       |Test Resource4 |
+
+  # Scenario 4
+  @api @39
+  Scenario: Check the "read more" link works
+    Given "resource" content:
+      |title          |status |field_resource_category |
+      |Test Resource1 |1      |Resources for Caregivers|
+
+    Given I am logged in as a user with the "anonymous user" role
+    When I visit "/resources"
+    And I click "Read more"
+    Then I should be on "resource/test-resource1"

--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -1,19 +1,49 @@
 Feature: Checks "Resources" View
   As a developer, I need to verify:
-  That the "Resources" view page and sort function exists
-  That the correct roles can view the page
+  That the "Resources" view page exists and correct roles can view page
+  That the sort and filters work
 
-# Scenario checks the "Resources" view page exists, roles can view, and sort exists.
+  # Scenarios for "Resources" View Page
+
   # Scenario 1
   @api @39
   Scenario Outline: Check the "Resources" view page exists and can be accessed
     Given I am logged in as a user with the "<role>" role
     When I visit "/resources"
     Then I should not see "Page Not Found"
-    And I should see "Sort by"
+    And I should see "Narrow list by Resource Category"
     Examples:
       |role               |
       |anonymous user     |
       |authenticated user |
       |staff              |
       |administrator      |
+
+  # Scenario 2
+  @api @39 @now
+  Scenario Outline: Check content is being sorted by category and title
+    Given "resource" content:
+      |title            |status |field_resource_category  |
+      |Test Resource1.1 |1      |Resources for Caregivers |
+      |Test Resource1.2 |1      |Resources for Caregivers |
+      |Test Resource2.1 |1      |Resources for Parents |
+      |Test Resource2.2 |1      |Resources for Parents |
+      |Test Resource3.1 |1      |Resources for People with AS |
+      |Test Resource3.2 |1      |Resources for People with AS |
+      |Test Resource4.1 |1      |Resources for Teachers |
+      |Test Resource4.2 |1      |Resources for Teachers |
+
+    Given I am logged in as a user with the "anonymous user" role
+    When I visit "/resources"
+    Then the "<view-row>" element should contain "<title>"
+    #Then the ".views-row-1" element should contain "Test Resource1.1"
+    Examples:
+      |view-row      |title            |
+      |.views-row-1  |Test Resource1.1 |
+      |.views-row-2  |Test Resource1.2 |
+      |.views-row-3  |Test Resource2.1 |
+      |.views-row-4  |Test Resource2.2 |
+      |.views-row-5  |Test Resource3.1 |
+      |.views-row-6  |Test Resource3.2 |
+      |.views-row-7  |Test Resource4.1 |
+      |.views-row-8  |Test Resource4.2 |

--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -48,8 +48,8 @@ Feature: Checks "Resources" View
       |.views-row-8  |Test Resource4.2 |
 
   # Scenario 3
-  @api @39
-  Scenario Outline: Check the category filter works
+  @api @39 @now
+  Scenario: Check the category filter works
     Given "resource" content:
       |title          |status |field_resource_category      |
       |Test Resource1 |1      |Resources for Caregivers     |
@@ -59,14 +59,12 @@ Feature: Checks "Resources" View
 
     Given I am logged in as a user with the "anonymous user" role
     When I visit "/resources"
-    And I select "<category>" from "Category"
-    Then I should see "<title>"
-    Examples:
-      |category                     |title          |
-      |Resources for Caregivers     |Test Resource1 |
-      |Resources for Parents        |Test Resource2 |
-      |Resources for People with AS |Test Resource3 |
-      |Resources for Teachers       |Test Resource4 |
+    And I select "Resources for Caregivers" from "Category"
+    And I press the "Apply" button
+    Then I should see "Test Resource1"
+    And I should not see "Test Resource2"
+    And I should not see "Test Resource3"
+    And I should not see "Test Resource4"
 
   # Scenario 4
   @api @39

--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -1,16 +1,16 @@
 Feature: Checks "Resources" View
   As a developer, I need to verify:
-  That the "Resources" view page exists
+  That the "Resources" view page and sort function exists
   That the correct roles can view the page
-  That the sort criteria works
 
-# Scenarios checks the "Resources" view page exists.
+# Scenario checks the "Resources" view page exists, roles can view, and sort exists.
   # Scenario 1
   @api @39
   Scenario Outline: Check the "Resources" view page exists and can be accessed
     Given I am logged in as a user with the "<role>" role
     When I visit "/resources"
     Then I should not see "Page Not Found"
+    And I should see "Sort by"
     Examples:
       |role               |
       |anonymous user     |

--- a/tests/features/views/resources.feature
+++ b/tests/features/views/resources.feature
@@ -1,0 +1,19 @@
+Feature: Checks "Resources" View
+  As a developer, I need to verify:
+  That the "Resources" view page exists
+  That the correct roles can view the page
+  That the sort criteria works
+
+# Scenarios checks the "Resources" view page exists.
+  # Scenario 1
+  @api @39
+  Scenario Outline: Check the "Resources" view page exists and can be accessed
+    Given I am logged in as a user with the "<role>" role
+    When I visit "/resources"
+    Then I should not see "Page Not Found"
+    Examples:
+      |role               |
+      |anonymous user     |
+      |authenticated user |
+      |staff              |
+      |administrator      |

--- a/www/sites/all/modules/custom/acs_master/acs_master.install
+++ b/www/sites/all/modules/custom/acs_master/acs_master.install
@@ -50,6 +50,7 @@ function _acs_master_all_modules() {
     'views_ui',
     'views_upcomingevents',
     'date_views',
+    'views_resources',
   );
   // 2. Return array as function output.
   return $arr_modules_ALL;
@@ -551,6 +552,32 @@ function acs_master_update_7112() {
   // 1. Create an array listing all module names for this update.
   $arr_modules = array(
     'date_views',
+  );
+
+  // 2. Enable each module in the array by passing to helper function.
+  // Store results in $msg for confirmation and error handling.
+  $msg = _acs_master_enable_modules($arr_modules);
+
+  // 3. Print confirmation message or throw exception if process unsuccessful.
+  if ($msg[1]) {
+    // 3.1 If $msg[1] = TRUE, then print confirmation string in 2nd element.
+    return $msg[2];
+  }
+  else {
+    // 3.2 If $msg[1] = FALSE, then print error message and throw Exception.
+    throw new DrupalUpdateException($msg[2]);
+  } // End if statement.
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Enables the following modules: views_resources.
+ */
+function acs_master_update_7113() {
+  // 1. Create an array listing all module names for this update.
+  $arr_modules = array(
+    'views_resources',
   );
 
   // 2. Enable each module in the array by passing to helper function.

--- a/www/sites/all/modules/features/resource_content/resource_content.features.field_base.inc
+++ b/www/sites/all/modules/features/resource_content/resource_content.features.field_base.inc
@@ -34,7 +34,7 @@ function resource_content_field_default_field_bases() {
   // Exported field_base: 'field_resource_category'.
   $field_bases['field_resource_category'] = array(
     'active' => 1,
-    'cardinality' => -1,
+    'cardinality' => 4,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_resource_category',
@@ -89,7 +89,7 @@ function resource_content_field_default_field_bases() {
   // Exported field_base: 'field_visitor_type'.
   $field_bases['field_visitor_type'] = array(
     'active' => 1,
-    'cardinality' => -1,
+    'cardinality' => 4,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_visitor_type',

--- a/www/sites/all/modules/features/resource_content/resource_content.features.field_instance.inc
+++ b/www/sites/all/modules/features/resource_content/resource_content.features.field_instance.inc
@@ -58,15 +58,17 @@ function resource_content_field_default_field_instances() {
     'description' => '',
     'display' => array(
       'default' => array(
-        'label' => 'hidden',
+        'label' => 'inline',
+        'module' => 'taxonomy',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'taxonomy_term_reference_link',
         'weight' => 3,
       ),
       'teaser' => array(
         'label' => 'above',
+        'module' => 'taxonomy',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'taxonomy_term_reference_plain',
         'weight' => 0,
       ),
     ),
@@ -78,12 +80,9 @@ function resource_content_field_default_field_instances() {
       'user_register_form' => FALSE,
     ),
     'widget' => array(
-      'active' => 0,
+      'active' => 1,
       'module' => 'options',
-      'settings' => array(
-        'autocomplete_path' => 'taxonomy/autocomplete',
-        'size' => 60,
-      ),
+      'settings' => array(),
       'type' => 'options_buttons',
       'weight' => 5,
     ),
@@ -154,9 +153,10 @@ function resource_content_field_default_field_instances() {
     'description' => '',
     'display' => array(
       'default' => array(
-        'label' => 'hidden',
+        'label' => 'inline',
+        'module' => 'taxonomy',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'taxonomy_term_reference_link',
         'weight' => 2,
       ),
       'teaser' => array(
@@ -174,12 +174,9 @@ function resource_content_field_default_field_instances() {
       'user_register_form' => FALSE,
     ),
     'widget' => array(
-      'active' => 0,
+      'active' => 1,
       'module' => 'options',
-      'settings' => array(
-        'autocomplete_path' => 'taxonomy/autocomplete',
-        'size' => 60,
-      ),
+      'settings' => array(),
       'type' => 'options_buttons',
       'weight' => 4,
     ),

--- a/www/sites/all/modules/features/resource_content/resource_content.features.field_instance.inc
+++ b/www/sites/all/modules/features/resource_content/resource_content.features.field_instance.inc
@@ -58,10 +58,9 @@ function resource_content_field_default_field_instances() {
     'description' => '',
     'display' => array(
       'default' => array(
-        'label' => 'inline',
-        'module' => 'taxonomy',
+        'label' => 'hidden',
         'settings' => array(),
-        'type' => 'taxonomy_term_reference_link',
+        'type' => 'hidden',
         'weight' => 3,
       ),
       'teaser' => array(
@@ -153,10 +152,9 @@ function resource_content_field_default_field_instances() {
     'description' => '',
     'display' => array(
       'default' => array(
-        'label' => 'inline',
-        'module' => 'taxonomy',
+        'label' => 'hidden',
         'settings' => array(),
-        'type' => 'taxonomy_term_reference_link',
+        'type' => 'hidden',
         'weight' => 2,
       ),
       'teaser' => array(

--- a/www/sites/all/modules/features/views_resources/views_resources.features.inc
+++ b/www/sites/all/modules/features/views_resources/views_resources.features.inc
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * views_resources.features.inc
+ */
+
+/**
+ * Implements hook_views_api().
+ */
+function views_resources_views_api($module = NULL, $api = NULL) {
+  return array("api" => "3.0");
+}

--- a/www/sites/all/modules/features/views_resources/views_resources.info
+++ b/www/sites/all/modules/features/views_resources/views_resources.info
@@ -1,0 +1,11 @@
+name = Views: Resources
+description = Feature captures configurations for the "Resources" view page
+core = 7.x
+package = Features
+version = 7.x-1.0-alpha1
+dependencies[] = views
+features[ctools][] = views:views_default:3.0
+features[features_api][] = api:2
+features[views_view][] = resources
+features_exclude[dependencies][ctools] = ctools
+project path = sites/all/modules/features

--- a/www/sites/all/modules/features/views_resources/views_resources.module
+++ b/www/sites/all/modules/features/views_resources/views_resources.module
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * Code for the Views: Resources feature.
+ */
+
+include_once 'views_resources.features.inc';

--- a/www/sites/all/modules/features/views_resources/views_resources.views_default.inc
+++ b/www/sites/all/modules/features/views_resources/views_resources.views_default.inc
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @file
+ * views_resources.views_default.inc
+ */
+
+/**
+ * Implements hook_views_default_views().
+ */
+function views_resources_views_default_views() {
+  $export = array();
+
+  $view = new view();
+  $view->name = 'resources';
+  $view->description = 'A sortable list of resources';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'Resources';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'Resources';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'perm';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'default';
+  $handler->display->display_options['row_plugin'] = 'node';
+  /* Relationship: Content: Taxonomy terms on node */
+  $handler->display->display_options['relationships']['term_node_tid']['id'] = 'term_node_tid';
+  $handler->display->display_options['relationships']['term_node_tid']['table'] = 'node';
+  $handler->display->display_options['relationships']['term_node_tid']['field'] = 'term_node_tid';
+  $handler->display->display_options['relationships']['term_node_tid']['label'] = 'Resource Categories';
+  $handler->display->display_options['relationships']['term_node_tid']['vocabularies'] = array(
+    'resources' => 'resources',
+    'forums' => 0,
+    'tags' => 0,
+    'visitor_type' => 0,
+  );
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  /* Sort criterion: Taxonomy term: Name */
+  $handler->display->display_options['sorts']['name']['id'] = 'name';
+  $handler->display->display_options['sorts']['name']['table'] = 'taxonomy_term_data';
+  $handler->display->display_options['sorts']['name']['field'] = 'name';
+  $handler->display->display_options['sorts']['name']['relationship'] = 'term_node_tid';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'resource' => 'resource',
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'resources';
+  $export['resources'] = $view;
+
+  return $export;
+}

--- a/www/sites/all/modules/features/views_resources/views_resources.views_default.inc
+++ b/www/sites/all/modules/features/views_resources/views_resources.views_default.inc
@@ -36,7 +36,8 @@ function views_resources_views_default_views() {
   $handler->display->display_options['relationships']['term_node_tid']['id'] = 'term_node_tid';
   $handler->display->display_options['relationships']['term_node_tid']['table'] = 'node';
   $handler->display->display_options['relationships']['term_node_tid']['field'] = 'term_node_tid';
-  $handler->display->display_options['relationships']['term_node_tid']['label'] = 'Resource Categories';
+  $handler->display->display_options['relationships']['term_node_tid']['label'] = 'Resource Terms';
+  $handler->display->display_options['relationships']['term_node_tid']['required'] = TRUE;
   $handler->display->display_options['relationships']['term_node_tid']['vocabularies'] = array(
     'resources' => 'resources',
     'forums' => 0,
@@ -55,8 +56,11 @@ function views_resources_views_default_views() {
   $handler->display->display_options['sorts']['name']['table'] = 'taxonomy_term_data';
   $handler->display->display_options['sorts']['name']['field'] = 'name';
   $handler->display->display_options['sorts']['name']['relationship'] = 'term_node_tid';
-  $handler->display->display_options['sorts']['name']['exposed'] = TRUE;
   $handler->display->display_options['sorts']['name']['expose']['label'] = 'Categories';
+  /* Sort criterion: Content: Title */
+  $handler->display->display_options['sorts']['title']['id'] = 'title';
+  $handler->display->display_options['sorts']['title']['table'] = 'node';
+  $handler->display->display_options['sorts']['title']['field'] = 'title';
   /* Filter criterion: Content: Published */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
@@ -71,6 +75,26 @@ function views_resources_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'resource' => 'resource',
   );
+  /* Filter criterion: Content: Resource Category (field_resource_category) */
+  $handler->display->display_options['filters']['field_resource_category_tid']['id'] = 'field_resource_category_tid';
+  $handler->display->display_options['filters']['field_resource_category_tid']['table'] = 'field_data_field_resource_category';
+  $handler->display->display_options['filters']['field_resource_category_tid']['field'] = 'field_resource_category_tid';
+  $handler->display->display_options['filters']['field_resource_category_tid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_resource_category_tid']['expose']['operator_id'] = 'field_resource_category_tid_op';
+  $handler->display->display_options['filters']['field_resource_category_tid']['expose']['label'] = 'Category';
+  $handler->display->display_options['filters']['field_resource_category_tid']['expose']['description'] = 'Narrow list by Resource Category';
+  $handler->display->display_options['filters']['field_resource_category_tid']['expose']['operator'] = 'field_resource_category_tid_op';
+  $handler->display->display_options['filters']['field_resource_category_tid']['expose']['identifier'] = 'field_resource_category_tid';
+  $handler->display->display_options['filters']['field_resource_category_tid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    5 => 0,
+    4 => 0,
+    3 => 0,
+  );
+  $handler->display->display_options['filters']['field_resource_category_tid']['reduce_duplicates'] = TRUE;
+  $handler->display->display_options['filters']['field_resource_category_tid']['type'] = 'select';
+  $handler->display->display_options['filters']['field_resource_category_tid']['vocabulary'] = 'resources';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');

--- a/www/sites/all/modules/features/views_resources/views_resources.views_default.inc
+++ b/www/sites/all/modules/features/views_resources/views_resources.views_default.inc
@@ -55,6 +55,8 @@ function views_resources_views_default_views() {
   $handler->display->display_options['sorts']['name']['table'] = 'taxonomy_term_data';
   $handler->display->display_options['sorts']['name']['field'] = 'name';
   $handler->display->display_options['sorts']['name']['relationship'] = 'term_node_tid';
+  $handler->display->display_options['sorts']['name']['exposed'] = TRUE;
+  $handler->display->display_options['sorts']['name']['expose']['label'] = 'Categories';
   /* Filter criterion: Content: Published */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';


### PR DESCRIPTION
For #39.

Hi @lhridley -

**Local tests passing and this PR is ready for official review**. I did the following:
- Wrote the behat test scenario for the Resources view page
- Created the view and exported the configs in a new feature `views_resources` (had to do some tweaking to the content type and view parameters)
- Enabled the new feature module via hooks

You're right, the Views module is definitely a bit confusing -- there are so many parameters and options (and some of them have very similar names) that it can be hard to figure out what I should be using for building. For example, the "Relationships" option under "Advanced" in the View settings has so many different choices relating to taxonomy terms and resource categories -- how do you know which ones to use?

![cs 39-relationships](https://cloud.githubusercontent.com/assets/19154706/18532312/3226a974-7a90-11e6-96e2-ab6894567784.png)
