### PR TITLE
[WIP] Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	- docker-compose exec php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
 	- docker-compose exec --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
 	- docker-compose exec --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
-	- docker-compose exec -T --user 82 php /bin/sh -c "mkdir ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"
+	- docker-compose exec -T --user 82 php /bin/sh -c "mkdir -p ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"
 	- docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer
 	- docker-compose exec -T --user 82 php drush sa
 	- make provision

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all: install
 
 install:
 	make up
-	docker-compose exec -T php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
-	docker-compose exec -T --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
+	-docker-compose exec php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
+	docker-compose exec -T --user 82 php /bin/sh -c "if [[ ! -f /var/www/html/www/sites/default/settings.php ]]; then cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php; fi"
 	docker-compose exec -T --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
 	docker-compose exec -T --user 82 php /bin/sh -c "mkdir -p ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"
 	docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer

--- a/Makefile
+++ b/Makefile
@@ -3,24 +3,24 @@ all: install
 
 install:
 	make up
-	docker-compose exec php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
-	docker-compose exec --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
-	docker-compose exec --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
+	docker-compose exec -T php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
+	docker-compose exec -T --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
+	docker-compose exec -T --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
 	docker-compose exec -T --user 82 php /bin/sh -c "mkdir -p ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"
 	docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer
 	docker-compose exec -T --user 82 php drush sa
 	make provision
 
 provision:
-	docker-compose exec --user 82 php drush @default.dev updb -y
-	docker-compose exec --user 82 php drush @default.dev cc all
-	docker-compose exec --user 82 php drush @default.dev pm-enable acs_master -y
-	docker-compose exec --user 82 php drush @default.dev fra -y
-	docker-compose exec --user 82 php drush @default.dev wd-del all -y
+	docker-compose exec -T --user 82 php drush @default.dev updb -y
+	docker-compose exec -T --user 82 php drush @default.dev cc all
+	docker-compose exec -T --user 82 php drush @default.dev pm-enable acs_master -y
+	docker-compose exec -T --user 82 php drush @default.dev fra -y
+	docker-compose exec -T --user 82 php drush @default.dev wd-del all -y
 	docker-compose ps
 
 update-tests:
-	docker-compose exec --user 82 php /bin/sh -c "cd /var/www/html/tests; composer update; bin/behat --init"
+	docker-compose exec -T --user 82 php /bin/sh -c "cd /var/www/html/tests; composer update; bin/behat --init"
 
 test:
 	make phpcs

--- a/Makefile
+++ b/Makefile
@@ -2,44 +2,44 @@
 all: install
 
 install:
-	- make up
-	- docker-compose exec php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
-	- docker-compose exec --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
-	- docker-compose exec --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
-	- docker-compose exec -T --user 82 php /bin/sh -c "mkdir -p ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"
-	- docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer
-	- docker-compose exec -T --user 82 php drush sa
-	- make provision
+	make up
+	docker-compose exec php /bin/sh -c "chown -Rf www-data:www-data /var/www/html"
+	docker-compose exec --user 82 php /bin/sh -c "cp /var/www/html/default/settings.php /var/www/html/www/sites/default/settings.php"
+	docker-compose exec --user 82 php /bin/sh -c "ls -l; cd tests; composer install"
+	docker-compose exec -T --user 82 php /bin/sh -c "mkdir -p ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"
+	docker-compose exec -T --user 82 php tests/bin/phpcs --config-set installed_paths /var/www/html/tests/vendor/drupal/coder/coder_sniffer
+	docker-compose exec -T --user 82 php drush sa
+	make provision
 
 provision:
-	- docker-compose exec --user 82 php drush @default.dev updb -y
-	- docker-compose exec --user 82 php drush @default.dev cc all
-	- docker-compose exec --user 82 php drush @default.dev pm-enable acs_master -y
-	- docker-compose exec --user 82 php drush @default.dev fra -y
-	- docker-compose exec --user 82 php drush @default.dev wd-del all -y
-	- docker-compose ps
+	docker-compose exec --user 82 php drush @default.dev updb -y
+	docker-compose exec --user 82 php drush @default.dev cc all
+	docker-compose exec --user 82 php drush @default.dev pm-enable acs_master -y
+	docker-compose exec --user 82 php drush @default.dev fra -y
+	docker-compose exec --user 82 php drush @default.dev wd-del all -y
+	docker-compose ps
 
 update-tests:
-	- docker-compose exec --user 82 php /bin/sh -c "cd /var/www/html/tests; composer update; bin/behat --init"
+	docker-compose exec --user 82 php /bin/sh -c "cd /var/www/html/tests; composer update; bin/behat --init"
 
 test:
-	- make phpcs
-	- docker-compose exec -T --user 82 php tests/bin/behat -c tests/behat.yml --tags=~@failing -f progress
+	make phpcs
+	docker-compose exec -T --user 82 php tests/bin/behat -c tests/behat.yml --tags=~@failing -f progress
 
 phpcs:
-	- docker-compose exec -T --user 82 php tests/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme tests/features www/sites/all/modules/custom --ignore=*.css,*.min.js,*addthis_widget.js,*features.*.inc
+	docker-compose exec -T --user 82 php tests/bin/phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme tests/features www/sites/all/modules/custom --ignore=*.css,*.min.js,*addthis_widget.js,*features.*.inc
 
 clean:
 	make stop
-	- docker rm $(docker-compose ps -q)
-	- docker-compose ps
+	docker rm $(docker-compose ps -q)
+	docker-compose ps
 
 clean-data:
-	- docker volume rm autismcasestudy_mysql-data
+	docker volume rm autismcasestudy_mysql-data
 
 stop:
-	- docker-compose down
+	docker-compose down
 
 up:
-	- docker-compose up -d
-	- sleep 10
+	docker-compose up -d
+	sleep 10


### PR DESCRIPTION
Hi @lhridley -

This PR is suggests some `Makefile` updates that I learned from @kostajh during a teleconsole troubleshooting session!

1. This command under `make install` was failing because `/home/www/.drush` already existed in the container and then the 2nd part of the command wasn't executing! So added the `-p` option to `mkdir`.
>`docker-compose exec -T --user 82 php /bin/sh -c "mkdir ~/.drush; cp /etc/drush/site-aliases/default.aliases.drushrc.php ~/.drush/default.aliases.drushrc.php"`

2. Removing all the leading `-`. The `-` was telling `make` to continue executing even if a step failed, so we removed it so things will be easier to debug!

3. I'm not sure we all fully understand this one, but replacing all `docker-compose exec` commands with `docker-compose exec -T`. This has something to do with a bug that occurs when Docker is running on Ubuntu (which is all cases where we run Travis tests). 

-4. Weirdly, my local repo permissions had to be updated after pulling the new container so I did `sudo chmod -R 777 /Users/Ro/src/autism-case-study`.

I'm going to try re-running my install with new containers on this branch -- hopefully it works and I'll report back here!  Just wanted to put a little description in here as a FYI.
