### PR TITLE
#43 Feed Aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ provision:
 	docker-compose exec -T --user 82 php drush @default.dev pm-enable acs_master -y
 	docker-compose exec -T --user 82 php drush @default.dev fra -y
 	docker-compose exec -T --user 82 php drush @default.dev wd-del all -y
+	docker-compose exec -T --user 82 php drush @default.dev cron
+	docker-compose exec -T --user 82 php drush @default.dev cc all
 	docker-compose ps
 
 update-tests:

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -122,6 +122,12 @@ default:
       contexts:
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MinkContext
+    feeds:
+      paths:
+        - %paths.base%/features/feeds
+      contexts:
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MinkContext
   gherkin:
     cache: ~
   extensions:

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -62,6 +62,7 @@ default:
                 - 'edit any event content'
                 - 'edit own event content'
                 - 'access site-wide contact form'
+                - 'access news feeds'
               authenticated user:
                 - 'access comments'
                 - 'post comments'
@@ -72,6 +73,7 @@ default:
                 - 'create forum content'
                 - 'edit own forum content'
                 - 'delete own forum content'
+                - 'access news feeds'
               anonymous user:
                 - 'access comments'
                 - 'post comments'
@@ -81,6 +83,7 @@ default:
                 - 'create forum content'
                 - 'edit own forum content'
                 - 'delete own forum content'
+                - 'access news feeds'
         - Drupal\DrupalExtension\Context\DrupalContext
     taxonomy:
       paths:

--- a/tests/features/feeds/latest-as-news.feature
+++ b/tests/features/feeds/latest-as-news.feature
@@ -1,0 +1,24 @@
+Feature: Checks "Latest AS News" Feed
+  As a developer, I need to verify:
+  That the "Latest AS News" Feed was created
+  That the feed can be viewed by all roles
+
+# Scenario 1
+  @api @43
+  Scenario: Check "Latest AS News" feed was created
+    Given I am logged in as a user with the "administrator" role
+    When I visit "admin/config/services/aggregator"
+    Then I should see "Latest AS News" in the "maincontent" region
+
+# Scenario: 2
+  @api @43
+  Scenario Outline: Check all roles can view the feed
+    Given I am logged in as a user with the "<role>" role
+    When I visit "/"
+    Then I should see "Latest AS News" in the "sidebar2" region
+    Examples:
+      |role               |
+      |anonymous user     |
+      |authenticated user |
+      |staff              |
+      |administrator      |

--- a/www/sites/all/modules/custom/acs_master/acs_master.install
+++ b/www/sites/all/modules/custom/acs_master/acs_master.install
@@ -57,6 +57,7 @@ function _acs_master_all_modules() {
     'blocks_upcomingevents',
     'contact_contact_us',
     'entity',
+    'block_feed_latest_news',
   );
   // 2. Return array as function output.
   return $arr_modules_ALL;
@@ -882,4 +883,30 @@ function acs_master_update_7121() {
 function acs_master_update_7122() {
   // 7. Call function that creates the Forum structure.
   _acs_master_create_forums();
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Enables the following modules: block_feed_latest_news.
+ */
+function acs_master_update_7123() {
+  // 1. Create an array listing all module names for this update.
+  $arr_modules = array(
+    'block_feed_latest_news',
+  );
+
+  // 2. Enable each module in the array by passing to helper function.
+  // Store results in $msg for confirmation and error handling.
+  $msg = _acs_master_enable_modules($arr_modules);
+
+  // 3. Print confirmation message or throw exception if process unsuccessful.
+  if ($msg[1]) {
+    // 3.1 If $msg[1] = TRUE, then print confirmation string in 2nd element.
+    return $msg[2];
+  }
+  else {
+    // 3.2 If $msg[1] = FALSE, then print error message and throw Exception.
+    throw new DrupalUpdateException($msg[2]);
+  } // End if statement.
 }

--- a/www/sites/all/modules/custom/acs_master/acs_master.install
+++ b/www/sites/all/modules/custom/acs_master/acs_master.install
@@ -230,8 +230,10 @@ function _acs_master_create_aggregator_feed() {
   $feed = array(
     'title' => 'Latest AS News',
     'url' => 'http://www.news-medical.net/tag/feed/aspergers-syndrome.aspx',
-    'refresh' => 3600, // Update interval in seconds
-    'block' => 5, // News items in block
+    // Update interval in seconds.
+    'refresh' => 3600,
+    // Items in block.
+    'block' => 5,
   );
   // 2. Save feed with Aggregator module.
   aggregator_save_feed($feed);

--- a/www/sites/all/modules/custom/acs_master/acs_master.install
+++ b/www/sites/all/modules/custom/acs_master/acs_master.install
@@ -220,6 +220,24 @@ function _acs_master_create_forums() {
 }
 
 /**
+ * Create "Latest AS News" Feed.
+ *
+ * Create the "Latest AS News" feed with the Aggregator Module.
+ */
+function _acs_master_create_aggregator_feed() {
+
+  // 1. "Latest AS News" feed configuration.
+  $feed = array(
+    'title' => 'Latest AS News',
+    'url' => 'http://www.news-medical.net/tag/feed/aspergers-syndrome.aspx',
+    'refresh' => 3600, // Update interval in seconds
+    'block' => 5, // News items in block
+  );
+  // 2. Save feed with Aggregator module.
+  aggregator_save_feed($feed);
+}
+
+/**
  * Implements hook_install().
  *
  * This function runs the first time this module ACS Master is enabled.
@@ -279,6 +297,9 @@ function acs_master_install() {
 
   // 7. Call function that creates the Forum structure.
   _acs_master_create_forums();
+
+  // 8. Call function that creates the "Latest AS News" feed with Aggregator.
+  _acs_master_create_aggregator_feed();
 }
 
 /**
@@ -888,9 +909,19 @@ function acs_master_update_7122() {
 /**
  * Implements hook_update_N().
  *
- * Enables the following modules: block_feed_latest_news.
+ * Creates the "Latest AS News" Feed.
  */
 function acs_master_update_7123() {
+  // 7. Call function that creates the Feed with Aggregator module.
+  _acs_master_create_aggregator_feed();
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Enables the following modules: block_feed_latest_news.
+ */
+function acs_master_update_7124() {
   // 1. Create an array listing all module names for this update.
   $arr_modules = array(
     'block_feed_latest_news',

--- a/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.features.fe_block_settings.inc
+++ b/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.features.fe_block_settings.inc
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @file
+ * block_feed_latest_news.features.fe_block_settings.inc
+ */
+
+/**
+ * Implements hook_default_fe_block_settings().
+ */
+function block_feed_latest_news_default_fe_block_settings() {
+  $export = array();
+
+  $export['version'] = '2.0';
+
+  $export['aggregator-feed-1'] = array(
+    'cache' => 1,
+    'custom' => 0,
+    'delta' => 'feed-1',
+    'module' => 'aggregator',
+    'node_types' => array(),
+    'pages' => '<front>',
+    'roles' => array(),
+    'themes' => array(
+      'bartik' => array(
+        'region' => 'sidebar_second',
+        'status' => 1,
+        'theme' => 'bartik',
+        'weight' => -11,
+      ),
+      'seven' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'seven',
+        'weight' => 0,
+      ),
+    ),
+    'title' => 'Latest AS News',
+    'visibility' => 1,
+  );
+
+  return $export;
+}

--- a/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.info
+++ b/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.info
@@ -1,0 +1,10 @@
+name = Block: Feed-Latest News
+description = Captures configuration for the Block displaying the "Latest AS News" feed
+core = 7.x
+package = Features
+version = 7.x-1.0-alpha1
+dependencies[] = aggregator
+dependencies[] = fe_block
+features[fe_block_settings][] = aggregator-feed-1
+features[features_api][] = api:2
+project path = sites/all/modules/features

--- a/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.module
+++ b/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.module
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Drupal needs this blank file.
+ */

--- a/www/sites/all/modules/features/roles_permissions/roles_permissions.features.user_permission.inc
+++ b/www/sites/all/modules/features/roles_permissions/roles_permissions.features.user_permission.inc
@@ -128,6 +128,8 @@ function roles_permissions_user_default_permissions() {
     'name' => 'access news feeds',
     'roles' => array(
       'administrator' => 'administrator',
+      'anonymous user' => 'anonymous user',
+      'authenticated user' => 'authenticated user',
       'site administrator' => 'site administrator',
     ),
     'module' => 'aggregator',


### PR DESCRIPTION
PR for #43 

Hi @lhridley -

Pushing these commits for your WIP review. I have a sneaking suspicion that somehow my feature is not quite capturing all of the Aggregator Feed's configurations. Do I have to write a custom hook_update the captures the feed just like `forums` and `about us` pages?

Here's what I did:
1. Created the "Latest AS News" feed using the Aggregator module
2. Configured the newly created feed's Block so that it shows up on the Homepage, under Sidebar2 (Pic1)
3. Created a feature module that captures the block configuration `block_feeds_latest_news`
(Pic2)
4. Enabled the feature via hooks

- **This seems right to me, but it also feels like I might be missing a step 1.5 where I need to save the Aggregator module's configuration. I can see where the new "item" got created in the `aggregator_feed` table in the DB -- is `block_feeds_latest_news` capturing it? (pic3)**

- Lastly, would it be better to use the "Feeds" module instead of "Aggregator"?

### Pic1
![cs 43-home](https://cloud.githubusercontent.com/assets/19154706/19502527/5533d940-9562-11e6-8e25-39e28e5571a1.png)

### Pic2
![cs 43-2](https://cloud.githubusercontent.com/assets/19154706/19502532/66474eb0-9562-11e6-9cf8-18f24fa1012d.png)

### Pic3
![cs -3](https://cloud.githubusercontent.com/assets/19154706/19502535/6e104a20-9562-11e6-9e4e-c3982f7f4517.png)

