### PR TITLE
#45 Page/Block Configurations

### DIFF
--- a/tests/features/feeds/latest-as-news.feature
+++ b/tests/features/feeds/latest-as-news.feature
@@ -12,9 +12,11 @@ Feature: Checks "Latest AS News" Feed
 
 # Scenario: 2
   @api @43
-  Scenario Outline: Check all roles can view the feed
+  Scenario Outline: Check all roles can view the feed on proper pages
     Given I am logged in as a user with the "<role>" role
     When I visit "/"
+    Then I should see "Latest AS News" in the "sidebar2" region
+    When I visit "/resources"
     Then I should see "Latest AS News" in the "sidebar2" region
     Examples:
       |role               |

--- a/tests/features/views/latestcontent.feature
+++ b/tests/features/views/latestcontent.feature
@@ -35,7 +35,7 @@ Feature: Checks "Latest Content" View
 
   # Scenario 2
   @api @30
-  Scenario Outline: Check the "latest content" block exists in homepage sidebar
+  Scenario Outline: Check the "latest content" block exists on homepage only
     Given "article" content:
       |title        |status |field_visitor_type |
       |TestArticle1 |1      |Caregivers         |
@@ -43,7 +43,9 @@ Feature: Checks "Latest Content" View
 
     Given I am logged in as a user with the "<role>" role
     When I visit "/"
-    Then I should see "Latest Content Posted" in the "sidebar2" region
+    Then I should see "Latest Content Posted" in the "maincontent" region
+    And I visit "/resources"
+    Then I should not see "Latest Content Posted" in the "maincontent" region
     Examples:
       |role               |
       |anonymous user     |

--- a/www/sites/all/modules/custom/acs_master/acs_master.install
+++ b/www/sites/all/modules/custom/acs_master/acs_master.install
@@ -59,6 +59,7 @@ function _acs_master_all_modules() {
     'entity',
     'block_feed_latest_news',
     'menu_main',
+    'block_navigation',
   );
   // 2. Return array as function output.
   return $arr_modules_ALL;
@@ -954,6 +955,32 @@ function acs_master_update_7125() {
   // 1. Create an array listing all module names for this update.
   $arr_modules = array(
     'menu_main',
+  );
+
+  // 2. Enable each module in the array by passing to helper function.
+  // Store results in $msg for confirmation and error handling.
+  $msg = _acs_master_enable_modules($arr_modules);
+
+  // 3. Print confirmation message or throw exception if process unsuccessful.
+  if ($msg[1]) {
+    // 3.1 If $msg[1] = TRUE, then print confirmation string in 2nd element.
+    return $msg[2];
+  }
+  else {
+    // 3.2 If $msg[1] = FALSE, then print error message and throw Exception.
+    throw new DrupalUpdateException($msg[2]);
+  } // End if statement.
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Enables the following modules: block_navigation.
+ */
+function acs_master_update_7126() {
+  // 1. Create an array listing all module names for this update.
+  $arr_modules = array(
+    'block_navigation',
   );
 
   // 2. Enable each module in the array by passing to helper function.

--- a/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.features.fe_block_settings.inc
+++ b/www/sites/all/modules/features/block_feed_latest_news/block_feed_latest_news.features.fe_block_settings.inc
@@ -18,14 +18,15 @@ function block_feed_latest_news_default_fe_block_settings() {
     'delta' => 'feed-1',
     'module' => 'aggregator',
     'node_types' => array(),
-    'pages' => '<front>',
+    'pages' => '<front>
+resources',
     'roles' => array(),
     'themes' => array(
       'bartik' => array(
         'region' => 'sidebar_second',
         'status' => 1,
         'theme' => 'bartik',
-        'weight' => -11,
+        'weight' => -12,
       ),
       'seven' => array(
         'region' => '',

--- a/www/sites/all/modules/features/block_latest_content/block_latest_content.features.fe_block_settings.inc
+++ b/www/sites/all/modules/features/block_latest_content/block_latest_content.features.fe_block_settings.inc
@@ -18,11 +18,11 @@ function block_latest_content_default_fe_block_settings() {
     'delta' => 'latest_content-block_1',
     'module' => 'views',
     'node_types' => array(),
-    'pages' => '',
+    'pages' => '<front>',
     'roles' => array(),
     'themes' => array(
       'bartik' => array(
-        'region' => 'sidebar_second',
+        'region' => 'content',
         'status' => 1,
         'theme' => 'bartik',
         'weight' => 0,
@@ -35,7 +35,7 @@ function block_latest_content_default_fe_block_settings() {
       ),
     ),
     'title' => '',
-    'visibility' => 0,
+    'visibility' => 1,
   );
 
   return $export;

--- a/www/sites/all/modules/features/block_navigation/block_navigation.features.fe_block_settings.inc
+++ b/www/sites/all/modules/features/block_navigation/block_navigation.features.fe_block_settings.inc
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @file
+ * block_navigation.features.fe_block_settings.inc
+ */
+
+/**
+ * Implements hook_default_fe_block_settings().
+ */
+function block_navigation_default_fe_block_settings() {
+  $export = array();
+
+  $export['version'] = '2.0';
+
+  $export['system-navigation'] = array(
+    'cache' => -1,
+    'custom' => 0,
+    'delta' => 'navigation',
+    'module' => 'system',
+    'node_types' => array(),
+    'pages' => '',
+    'roles' => array(),
+    'themes' => array(
+      'bartik' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'bartik',
+        'weight' => 0,
+      ),
+      'seven' => array(
+        'region' => '',
+        'status' => 0,
+        'theme' => 'seven',
+        'weight' => 0,
+      ),
+    ),
+    'title' => '',
+    'visibility' => 0,
+  );
+
+  return $export;
+}

--- a/www/sites/all/modules/features/block_navigation/block_navigation.info
+++ b/www/sites/all/modules/features/block_navigation/block_navigation.info
@@ -1,0 +1,9 @@
+name = Block: Navigation
+description = Captures configuration for the "Navigation" Block
+core = 7.x
+package = Features
+version = 7.x-1.0-alpha1
+dependencies[] = fe_block
+features[fe_block_settings][] = system-navigation
+features[features_api][] = api:2
+project path = sites/all/modules/features

--- a/www/sites/all/modules/features/block_navigation/block_navigation.module
+++ b/www/sites/all/modules/features/block_navigation/block_navigation.module
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Drupal needs this blank file.
+ */

--- a/www/sites/all/modules/features/blocks_upcomingevents/blocks_upcomingevents.features.fe_block_settings.inc
+++ b/www/sites/all/modules/features/blocks_upcomingevents/blocks_upcomingevents.features.fe_block_settings.inc
@@ -18,14 +18,18 @@ function blocks_upcomingevents_default_fe_block_settings() {
     'delta' => 'upcoming_events-block_1',
     'module' => 'views',
     'node_types' => array(),
-    'pages' => '',
+    'pages' => '<front>
+parents
+teachers
+caregivers
+people-with-AS',
     'roles' => array(),
     'themes' => array(
       'bartik' => array(
         'region' => 'sidebar_second',
         'status' => 1,
         'theme' => 'bartik',
-        'weight' => 0,
+        'weight' => -13,
       ),
       'seven' => array(
         'region' => '',
@@ -35,7 +39,7 @@ function blocks_upcomingevents_default_fe_block_settings() {
       ),
     ),
     'title' => '',
-    'visibility' => 0,
+    'visibility' => 1,
   );
 
   return $export;


### PR DESCRIPTION
Hi @lhridley -

This PR is ready for official review. 
- The blocks are all configured to be on the correct pages and I updated the tests to reflect the changes (we'd already captured most of the tests when we created the blocks previously, so they just needed minor adjustments).
- The one thing I changed form the instructions was to keep the blocks "Latest AS News" and "Upcoming Events" on `sidebar2` instead of `sidebar1`. Just because I thought it looked cluttered with the "log in" block and there was space in `sidebar1`.
- Also I removed the "navigation" block -- it seemed superfluous once the Main Menu navigation gets merged in.
