### PR TITLE
[WIP] #46 Additional Behat Tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,8 @@ services:
 #      - "8005:6082" # Control terminal
   selenium:
     container_name: selenium
-    image: selenium/standalone-chrome:2.53.0
+    #image: selenium/standalone-chrome:2.53.0
+    image: selenium/standalone-firefox:2.53.1
 
 volumes:
   mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - '33306:3306'
 
   php:
-    image: wodby/drupal-php:5.6 # Allowed: 7.0, 5.6.
+    image: wodby/drupal-php:5.6-build-41 # Allowed: 7.0, 5.6.
     environment:
       PHP_SITE_NAME: dev
       PHP_HOST_NAME: localhost:8000

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -134,6 +134,12 @@ default:
       contexts:
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MinkContext
+    extras:
+      paths:
+        - %paths.base%/features/extra-tests
+      contexts:
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MinkContext
   gherkin:
     cache: ~
   extensions:
@@ -163,6 +169,7 @@ default:
         maincontent: "#content"
         comments: "#comments"
         main_menu: "#main-menu-links"
+        toolbar: "#toolbar"
       selectors:
         message_selector: '.messages'
         error_message_selector: '.messages.error'

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -165,6 +165,7 @@ default:
         content: ".content"
         taxonomy: "#taxonomy"
         fields: "#field-overview"
+        sidebar1: "#sidebar-first"
         sidebar2: "#sidebar-second"
         maincontent: "#content"
         comments: "#comments"

--- a/tests/behat.yml
+++ b/tests/behat.yml
@@ -150,7 +150,8 @@ default:
     Behat\MinkExtension:
       goutte: ~
       selenium2:
-        browser: 'chrome'
+        #browser: 'chrome'
+        browser: 'firefox'
         wd_host: selenium:4444/wd/hub
       base_url: http://nginx
     Drupal\DrupalExtension:

--- a/tests/features/extra-tests/content-creation.feature
+++ b/tests/features/extra-tests/content-creation.feature
@@ -1,53 +1,222 @@
 Feature: Runs through "content creation" scenarios
-  As a developer
-  I need to verify that created content behaves as we expect
+  As a developer, I need to verify
+  Anonymous, Staff, and Site Admin roles can interact with content properly
+  That the created content behaves as we expect
 
+# Scenarios 1-4 Check that Staff users can create content on the site properly
 # Scenario 1
   @api @46
-  Scenario: Create Basic Page and Articles for each Visitor Type
+  Scenario Outline: Staff user creates Basic Article for Parents
     Given I am logged in as a user with the "staff" role
     When I visit "/"
-    And I click "Content" in the "toolbar" region
-    And I click "Add content"
-    And I click "Article"
-    And I fill in the following:
-      | Title        | Parent Article                 |
-      | Body         | This is an article for Parents |
-      | Visitor Type | Parents                        |
-    And I visit "/"
-    Then I should see "This is an article for Parents" in the "maincontent" region
+    And I click "Add content" in the "sidebar1" region
+    And I click "Article" in the "maincontent" region
+      And I fill in the following:
+        | Title | Parent Article                 |
+        | Body  | This is an article for Parents |
+      And I check the box "Parents"
+      And I press the "Save" button
+    Then I visit "/"
+    Then I should see "Parent Article" in the "maincontent" region
     And I visit "/parents"
-    Then I should see "This is an article for Parents" in the "maincontent" region
-    And I visit "/teachers"
-    Then I should not see "This is an article for Parents" in the "maincontent" region
+    Then I should see "Parent Article" in the "maincontent" region
+    And I visit "<path>"
+    Then I should not see "<text>" in the "maincontent" region
+    Examples:
+      | path            | text        |
+      | /teachers       | Parent Page |
+      | /caregivers     | Parent Page |
+      | /people-with-AS | Parent Page |
 
-#    And I fill in the following:
-#      | Subject | Topic1 |
-#      | Body    | We like chocolate! |
-#    And I select "General Topics" from "Forums"
-#    And I press the "Save" button
-#
-#    Given "event" content:
-#      |title      |status |field_visitor_type |field_start_date    |field_end_date      |
-#      |TestEvent1 |1      |Caregivers         |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
-#      |TestEvent2 |1      |Parents            |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
-#      |TestEvent3 |1      |People with AS     |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
-#      |TestEvent4 |1      |Teachers           |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
-#
-#    Given "Article" content:
-#      | title         | status | body | field_visitor_type|
-#      | Test Article1 | 1      | ABC  | Parents           |
-#      | Test Article2 | 1      | DEF  | Parents           |
-#      | Test Article3 | 1      | GHI  | Parents           |
-#      | Test Article4 | 1      | JKL  | Parents           |
-#      | Test Article5 | 1      | MNO  | Parents           |
-#    Given I am logged in as a user with the "staff" role
-#    When I am at "<path>"
-#    Then I should not see "Visitor Type"
-#  Examples:
-#  | path              |
-#  | article/test-article1 |
-#  | article/test-article2 |
-#  | article/test-article3 |
-#  | article/test-article4 |
-#  | article/test-article5 |
+# Scenario 2
+  @api @46
+  Scenario Outline: Staff user creates Basic Page for Parents
+    Given I am logged in as a user with the "staff" role
+    When I visit "/"
+    And I click "Add content" in the "sidebar1" region
+    And I click "Basic page" in the "maincontent" region
+      And I fill in the following:
+        | Title | Parent Page                 |
+        | Body  | This is a page for Parents  |
+      And I check the box "Parents"
+      And I press the "Save" button
+    Then I visit "/"
+    Then I should see "Parent Page" in the "maincontent" region
+    And I visit "/parents"
+    Then I should see "Parent Page" in the "maincontent" region
+    And I visit "<path>"
+    Then I should not see "<text>" in the "maincontent" region
+    Examples:
+      | path            | text        |
+      | /teachers       | Parent Page |
+      | /caregivers     | Parent Page |
+      | /people-with-AS | Parent Page |
+
+# Scenario 3
+  @api @46 @wip
+  Scenario: Staff user creates Basic Event for Parents
+    Given I am logged in as a user with the "staff" role
+    When I visit "/"
+    And I click "Add content" in the "sidebar1" region
+    And I click "Event" in the "maincontent" region
+      And I fill in the following:
+        | Title        | Parent Event       |
+        | Location     | London             |
+        | Description  | Event for Parents  |
+        | Start Time   | 09:00 AM           |
+        | End Time     | 05:00 PM           |
+      And I check the box "Parents"
+      And I press the "Save" button
+    # These below steps are failing even though it works manually...
+    And I visit "/parents"
+    Then I should see "Parent Event" in the "sidebar2" region
+    Then I visit "/"
+    Then I should see "Parent Event" in the "sidebar2" region
+
+
+# Scenario 4
+  @api @46 @wip
+  Scenario: Staff user creates 2 Resources tagged to different Visitor Types
+    Given I am logged in as a user with the "staff" role
+      When I visit "/"
+      And I click "Add content" in the "sidebar1" region
+      And I click "Resource" in the "maincontent" region
+        And I fill in "ParentResource1" for "Title"
+        And I fill in the following:
+          | title       | ParentResource1     |
+          | Description | Resource for Parents|
+          | URL         | www.bbc.com         |
+        And I check the box "Parents"
+        And I check the box "Resources for Parents"
+        And I press "Save"
+      When I visit "/"
+      And I click "Add content" in the "sidebar1" region
+      And I click "Resource" in the "maincontent" region
+        And I fill in "ParentResource1" for "Title"
+        And I fill in the following:
+          | title       | TeacherResource1     |
+          | Description | Resource for Teachers|
+          | URL         | www.bbc.com          |
+        And I check the box "Teachers"
+        And I check the box "Resources for Teachers"
+        And I press "Save"
+
+      Then I visit "/resources"
+        #clearly on page and this works
+        Then I should see "Navigation"
+        And I should see "Resources for Parents"
+        And I should see "Resources for Teachers"
+        #why can't the "title" text be found? Works manually...
+        And I should see "ParentResource1"
+        And I should see "TeacherResource1"
+
+# This scenario checks Pages tagged with different Visitor Types show up in the
+# correct places. The "articles" and "events" have already been checked for this
+# in other test suites.
+# Scenario 5
+  @api @46
+  Scenario Outline: Check Pages tagged with different visitor types behaves as expected
+    Given "Basic page" content:
+      | title        | status | body | field_visitor_type |
+      | PageParent   | 1      | ABC  | Parents            |
+      | PageTeacher  | 1      | ABC  | Teachers            |
+      | PageCaregiver| 1      | ABC  | Caregivers          |
+      | PagePeople   | 1      | ABC  | People with AS     |
+    
+    Given I am logged in as a user with the "staff" role
+      When I visit "/"
+        Then I should see "PageParent" in the "maincontent" region
+        Then I should see "PageTeacher" in the "maincontent" region
+        Then I should see "PageCaregiver" in the "maincontent" region
+        Then I should see "PagePeople" in the "maincontent" region
+      And I visit "<path>"
+        Then I should see "<correct>" in the "maincontent" region
+        And I should not see "<wrong2>" in the "maincontent" region
+        And I should not see "<wrong3>" in the "maincontent" region
+        And I should not see "<wrong4>" in the "maincontent" region
+      Examples:
+        | path            | correct       | wrong2     | wrong3       | wrong4      |
+        | /parents        | PageParent    | PageTeacher| PageCaregiver| PagePeople  |
+        | /teachers       | PageTeacher   | PageParent | PageCaregiver| PagePeople  |
+        | /caregivers     | PageCaregiver | PageParent | PageTeacher  | PagePeople  |
+        | /people-with-AS | PagePeople    | PageParent | PageCaregiver| PageTeacher |
+
+# This scenarios checks that Anonymous Users have correct restricted settings
+  # Scenario 6
+  @api @46
+  Scenario Outline: Check Anonymous User cannot create Page, Article, or Event
+    Given I am logged in as a user with the "anonymous user" role
+      When I visit "/"
+      And I click "Add content" in the "sidebar1" region
+      Then I should see "Create Forum topic" in the "maincontent" region
+      And I should not see "<check1>" in the "sidebar1" region
+    Examples:
+      | check1 |
+      | Article |
+      | Basic page |
+      | Blog entry |
+      | Event |
+      | Resource |
+
+# These scnearios check that Site Admin users can create Page, Article, and Event
+  # Scenario 7
+  @api @46
+  Scenario Outline: Check Site Admin user can create an Article and Page
+    Given I am logged in as a user with the "site administrator" role
+      When I visit "/"
+      And I click "Add content" in the "sidebar1" region
+      And I click "<content>" in the "maincontent" region
+        And I fill in the following:
+          | Title | <title> |
+          | Body  | <body>  |
+        And I check the box "<visitor>"
+        And I press the "Save" button
+      Then I visit "/"
+      Then I should see "<title>" in the "maincontent" region
+  Examples:
+    | content     | title          | body                           | visitor|
+    | Article     | Parent Article | This is an article for Parents | Parents|
+    | Basic page  | Parent Page    | This is a Page for Parents     | Parents|
+
+  # Scenario 8
+  @api @46 @wip
+  Scenario: Check Site Admin user can create an Event
+    Given I am logged in as a user with the "site administrator" role
+    When I visit "/"
+    And I click "Add content" in the "sidebar1" region
+    And I click "Event" in the "maincontent" region
+      And I fill in the following:
+        | Title        | Parent Event       |
+        | Location     | London             |
+        | Description  | Event for Parents  |
+        | Start Time   | 09:00 AM           |
+        | End Time     | 05:00 PM           |
+      And I check the box "Parents"
+      And I press the "Save" button
+    Then I visit "/"
+    # This step also failing thought it works manually....
+    And I click "Parent Event"
+    Then I should be on "/parent-event"
+
+# This scenario checks if Staff and Site Admin users can edit content
+  # Scenario 9
+  @api @46
+  Scenario Outline: Check Site Admin and Staff can edit content
+    Given "Basic page" content:
+      | title        | status | body | field_visitor_type |
+      | PageTeacher  | 1      | ABC  | Teachers           |
+
+    Given I am logged in as a user with the "<role>" role
+      When I visit "/"
+      And I click "PageTeacher" in the "maincontent" region
+        Then I should be on "page/pageteacher"
+          And I click "Edit" in the "maincontent" region
+          And I fill in "Unicorn kisses" for "Body"
+          And I press the "Save" button
+        Then I should be on "page/pageteacher"
+          And I should see "Unicorn kisses" in the "maincontent" region
+
+  Examples:
+    | role  |
+    | site administrator  |
+    | staff               |

--- a/tests/features/extra-tests/content-creation.feature
+++ b/tests/features/extra-tests/content-creation.feature
@@ -1,0 +1,53 @@
+Feature: Runs through "content creation" scenarios
+  As a developer
+  I need to verify that created content behaves as we expect
+
+# Scenario 1
+  @api @46
+  Scenario: Create Basic Page and Articles for each Visitor Type
+    Given I am logged in as a user with the "staff" role
+    When I visit "/"
+    And I click "Content" in the "toolbar" region
+    And I click "Add content"
+    And I click "Article"
+    And I fill in the following:
+      | Title        | Parent Article                 |
+      | Body         | This is an article for Parents |
+      | Visitor Type | Parents                        |
+    And I visit "/"
+    Then I should see "This is an article for Parents" in the "maincontent" region
+    And I visit "/parents"
+    Then I should see "This is an article for Parents" in the "maincontent" region
+    And I visit "/teachers"
+    Then I should not see "This is an article for Parents" in the "maincontent" region
+
+#    And I fill in the following:
+#      | Subject | Topic1 |
+#      | Body    | We like chocolate! |
+#    And I select "General Topics" from "Forums"
+#    And I press the "Save" button
+#
+#    Given "event" content:
+#      |title      |status |field_visitor_type |field_start_date    |field_end_date      |
+#      |TestEvent1 |1      |Caregivers         |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
+#      |TestEvent2 |1      |Parents            |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
+#      |TestEvent3 |1      |People with AS     |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
+#      |TestEvent4 |1      |Teachers           |2017-09-01 00:00:00 |2017-09-02 00:00:00 |
+#
+#    Given "Article" content:
+#      | title         | status | body | field_visitor_type|
+#      | Test Article1 | 1      | ABC  | Parents           |
+#      | Test Article2 | 1      | DEF  | Parents           |
+#      | Test Article3 | 1      | GHI  | Parents           |
+#      | Test Article4 | 1      | JKL  | Parents           |
+#      | Test Article5 | 1      | MNO  | Parents           |
+#    Given I am logged in as a user with the "staff" role
+#    When I am at "<path>"
+#    Then I should not see "Visitor Type"
+#  Examples:
+#  | path              |
+#  | article/test-article1 |
+#  | article/test-article2 |
+#  | article/test-article3 |
+#  | article/test-article4 |
+#  | article/test-article5 |

--- a/tests/features/extra-tests/content-creation.feature
+++ b/tests/features/extra-tests/content-creation.feature
@@ -53,7 +53,7 @@ Feature: Runs through "content creation" scenarios
       | /people-with-AS | Parent Page |
 
 # Scenario 3
-  @api @46 @wip
+  @api @46 @failing
   Scenario: Staff user creates Basic Event for Parents
     Given I am logged in as a user with the "staff" role
     When I visit "/"
@@ -75,7 +75,7 @@ Feature: Runs through "content creation" scenarios
 
 
 # Scenario 4
-  @api @46 @wip
+  @api @46 @failing
   Scenario: Staff user creates 2 Resources tagged to different Visitor Types
     Given I am logged in as a user with the "staff" role
       When I visit "/"
@@ -179,7 +179,7 @@ Feature: Runs through "content creation" scenarios
     | Basic page  | Parent Page    | This is a Page for Parents     | Parents|
 
   # Scenario 8
-  @api @46 @wip
+  @api @46 @failing
   Scenario: Check Site Admin user can create an Event
     Given I am logged in as a user with the "site administrator" role
     When I visit "/"

--- a/www/sites/all/modules/features/block_navigation/block_navigation.features.fe_block_settings.inc
+++ b/www/sites/all/modules/features/block_navigation/block_navigation.features.fe_block_settings.inc
@@ -22,8 +22,8 @@ function block_navigation_default_fe_block_settings() {
     'roles' => array(),
     'themes' => array(
       'bartik' => array(
-        'region' => '',
-        'status' => 0,
+        'region' => 'sidebar_first',
+        'status' => 1,
         'theme' => 'bartik',
         'weight' => 0,
       ),


### PR DESCRIPTION
PR for #46 

Hi @lhridley -
I added some additional test scenarios based on what was still missing from pg. 252-254 (most have already been captured by previous issues). 

I'm running into a **similar problem with #44, where I'm getting a failing step in the Behat but it actually works when I click on the site physically**.  I tried adding the `@javascript` tag, but _that just produced a different error_! If you could take a look and lend me your thoughts that'd be much appreciated!

Details
- For scenarios 3, 4, and 8 in `content-creation.feature` file
- For some reason Behat fails to see the newly created "Event" show up on the "Home" and "Parent" pages, even though I can see them on the site when I go through the same process (see **Pics 1, 2, 3**)
- I added the `@javascript` tag thinking that would fix this, but instead get a new error that I can only solve by _removing_ the tag again (**Pic 4**)

**Pic1 Failing Step** 
![cs 46-fail](https://cloud.githubusercontent.com/assets/19154706/19946300/edf5dee0-a100-11e6-8e99-0a6ba9be68f5.png)

**Pic2 Home Page**
![cs 46-home](https://cloud.githubusercontent.com/assets/19154706/19946463/7742a386-a101-11e6-82c1-8bf1a93ebe5c.png)


**Pic3 Specific Page**
![cs 46-page](https://cloud.githubusercontent.com/assets/19154706/19946474/7e38adac-a101-11e6-888e-5d84b73e78df.png)


**Pic4 Javascript tag cause new error**
![cs 46-js tag](https://cloud.githubusercontent.com/assets/19154706/19946496/8e3c4862-a101-11e6-8b94-2d10ddaf6ea7.png)
